### PR TITLE
feat: use `parts()` instead of `split` for some path operations.

### DIFF
--- a/c_binder_mojo/docs/generate_docs.mojo
+++ b/c_binder_mojo/docs/generate_docs.mojo
@@ -347,14 +347,14 @@ fn generate_docs(json_path: Path) raises:
 
     for module in root_object["modules"].array():
         doc_dispatch(
-            Path(String("/").join(json_path.path.split("/")[:-2])),
+            Path(String("/").join(json_path.parts()[:-2])),
             "",
             module.object(),
         )
 
     for package in root_object["packages"].array():
         doc_dispatch(
-            Path(String("/").join(json_path.path.split("/")[:-2])),
+            Path(String("/").join(json_path.parts()[:-2])),
             "",
             package.object(),
         )


### PR DESCRIPTION
Blocked by https://github.com/modular/modular/pull/5222